### PR TITLE
support createFolderStructureWith

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,28 @@ yarn add --dev create-folder-structure
      },
    })
    ```
+
+---
+
+`createFolderStructureWith` is a syntax sugar provided for `createFolderStructure` in order to reduce the boilerplate
+
+
+1. Create anonymous folder
+
+   ```typescript
+   import {createFolderStructureWith} from 'create-folder-structure'
+
+   const entryPath = await createFolderStructureWith({
+       file7: 'file content7',
+       ['folder6/folder7']: {},
+     })
+   ```
+
+2. Create anonymous file
+
+   ```typescript
+   import {createFolderStructureWith} from 'create-folder-structure'
+
+   const entryPath = await createFolderStructureWith('file content1')
+   ```
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,11 @@ export type EntryStructure = {
   content: string | {} | FolderStructure
 }
 
+export async function createFolderStructureWith(content: string | {} | FolderStructure): Promise<string> {
+  const originalResult = await createFolderStructure({ content })
+  return originalResult.entryPath
+}
+
 export default async function createFolderStructure(
   structure: EntryStructure,
 ): Promise<{

--- a/tests/tests.spec.ts
+++ b/tests/tests.spec.ts
@@ -1,6 +1,6 @@
 import * as Chance from 'chance'
 import testWithTypedContext, { TestInterface, ExecutionContext } from 'ava'
-import createFolderStructure from '../src'
+import createFolderStructure, { createFolderStructureWith } from '../src'
 import * as fse from 'fs-extra'
 import * as pathExists from 'path-exists'
 import * as path from 'path'
@@ -207,4 +207,13 @@ test('11 - non-json-extension will be a folder if the content is object', async 
   await assertFolderExist(t, entryPath)
   await assertFileExist(t, path.join(entryPath, 'a'), hash1)
   await assertFileExist(t, path.join(entryPath, 'b'), hash2)
+})
+
+test('12 - createFolderStructureWith proxies to createFolderStructure', async t => {
+  const hash = chance.hash()
+  const entryPath = await createFolderStructureWith({
+    'file.txt': hash,
+  })
+
+  await assertFileExist(t, path.join(entryPath, 'file.txt'), hash)
 })


### PR DESCRIPTION
provides a syntax sugar for createFolderStructure as following:


1. Create anonymous folder

   ```typescript
   import {createFolderStructureWith} from 'create-folder-structure'

   const entryPath = await createFolderStructureWith({
       file7: 'file content7',
       ['folder6/folder7']: {},
     })
   ```

2. Create anonymous file

   ```typescript
   import {createFolderStructureWith} from 'create-folder-structure'

   const entryPath = await createFolderStructureWith('file content1')
   ```